### PR TITLE
[Merge] Issue-9(여러 모달 선언 시 마지막 모달만 반영되는 문제) to HC-54

### DIFF
--- a/src/components/organisms/modals/AlertModal.tsx
+++ b/src/components/organisms/modals/AlertModal.tsx
@@ -10,8 +10,6 @@ export default function AlertModal() {
   const { title, message, onClickConfirm, buttonContent, isOpen } =
     useRecoilValue(AlertModalAtom);
 
-  console.log('AlertModal rendered!!');
-
   return isOpen ? (
     <ModalContainer>
       <Container.FlexCol className="w-full max-w-96 gap-3 rounded-2xl bg-bg p-6 text-brown">

--- a/src/components/organisms/modals/AlertModal.tsx
+++ b/src/components/organisms/modals/AlertModal.tsx
@@ -4,13 +4,16 @@ import Button from '@/components/atoms/Button';
 import Container from '@/components/atoms/Container';
 import Typography from '@/components/atoms/Typography';
 import { AlertModalAtom } from '@/stores/globalModal.store';
+import ModalContainer from '@/components/organisms/modals/ModalContainer';
 
 export default function AlertModal() {
-  const { title, message, onClickConfirm, buttonContent } =
+  const { title, message, onClickConfirm, buttonContent, isOpen } =
     useRecoilValue(AlertModalAtom);
 
-  return (
-    <Container.FlexRow className="fixed left-0 top-0 z-50 h-[100vh] w-[100vw] items-center justify-center bg-[#6D6D6D]/50">
+  console.log('AlertModal rendered!!');
+
+  return isOpen ? (
+    <ModalContainer>
       <Container.FlexCol className="w-full max-w-96 gap-3 rounded-2xl bg-bg p-6 text-brown">
         <Container.FlexCol className="gap-6">
           <Typography.SubTitle3>{title}</Typography.SubTitle3>
@@ -28,8 +31,8 @@ export default function AlertModal() {
           </Button.Ghost>
         </Container.FlexRow>
       </Container.FlexCol>
-    </Container.FlexRow>
-  );
+    </ModalContainer>
+  ) : null;
 }
 
 AlertModal.defaultProps = {

--- a/src/components/organisms/modals/ConfirmModal.tsx
+++ b/src/components/organisms/modals/ConfirmModal.tsx
@@ -4,9 +4,11 @@ import Button from '@/components/atoms/Button';
 import Container from '@/components/atoms/Container';
 import Typography from '@/components/atoms/Typography';
 import { ConfirmModalAtom } from '@/stores/globalModal.store';
+import ModalContainer from '@/components/organisms/modals/ModalContainer';
 
 export default function ConfirmModal() {
   const {
+    isOpen,
     title,
     message,
     confirmButtonContent,
@@ -15,8 +17,9 @@ export default function ConfirmModal() {
     onClickCancel,
   } = useRecoilValue(ConfirmModalAtom);
 
-  return (
-    <Container.FlexRow className="fixed left-0 top-0 z-50 h-[100vh] w-[100vw] items-center justify-center bg-[#6D6D6D]/50">
+  console.log('confirm modal rendered!!');
+  return isOpen ? (
+    <ModalContainer>
       <Container.FlexCol className="w-full max-w-96 gap-3 rounded-2xl bg-bg p-6 text-brown">
         <Container.FlexCol className="gap-6">
           <Typography.SubTitle3>{title}</Typography.SubTitle3>
@@ -43,8 +46,8 @@ export default function ConfirmModal() {
           </Button.Ghost>
         </Container.FlexRow>
       </Container.FlexCol>
-    </Container.FlexRow>
-  );
+    </ModalContainer>
+  ) : null;
 }
 
 ConfirmModal.defaultProps = {

--- a/src/components/organisms/modals/ConfirmModal.tsx
+++ b/src/components/organisms/modals/ConfirmModal.tsx
@@ -17,7 +17,6 @@ export default function ConfirmModal() {
     onClickCancel,
   } = useRecoilValue(ConfirmModalAtom);
 
-  console.log('confirm modal rendered!!');
   return isOpen ? (
     <ModalContainer>
       <Container.FlexCol className="w-full max-w-96 gap-3 rounded-2xl bg-bg p-6 text-brown">

--- a/src/components/organisms/modals/ModalContainer.tsx
+++ b/src/components/organisms/modals/ModalContainer.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react';
+
+import Container from '@/components/atoms/Container';
+
+type ModalContainerType = {
+  children: ReactNode;
+};
+
+export default function ModalContainer({ children }: ModalContainerType) {
+  return (
+    <Container.FlexRow className="fixed left-0 top-0 z-50 h-[100vh] w-[100vw] items-center justify-center bg-[#6D6D6D]/50">
+      {children}
+    </Container.FlexRow>
+  );
+}

--- a/src/components/organisms/modals/ProfileModal.tsx
+++ b/src/components/organisms/modals/ProfileModal.tsx
@@ -1,9 +1,14 @@
 import { useRecoilValue } from 'recoil';
 
 import { ProfileModalAtom } from '@/stores/globalModal.store';
+import ModalContainer from '@/components/organisms/modals/ModalContainer';
 
 export default function ProfileModal() {
-  const profileModalState = useRecoilValue(ProfileModalAtom);
+  const { isOpen } = useRecoilValue(ProfileModalAtom);
 
-  return <div>ConfirmModal</div>;
+  return isOpen ? (
+    <ModalContainer>
+      <div>ConfirmModal</div>
+    </ModalContainer>
+  ) : null;
 }

--- a/src/components/pages/ComponentTest.tsx
+++ b/src/components/pages/ComponentTest.tsx
@@ -87,8 +87,6 @@ export default function ComponentTest() {
   const [rangeValue, setRangeValue] = useState<number>(0);
   const formValues = useForm();
 
-  console.log('📝📝📝 component Test is rendered!!');
-
   return (
     <div className="flex flex-col bg-bg p-8">
       {/* Button test */}

--- a/src/components/pages/ComponentTest.tsx
+++ b/src/components/pages/ComponentTest.tsx
@@ -25,6 +25,7 @@ import Carousel from '@/components/organisms/Carousel';
 import DistrictSelector from '@/components/organisms/districtSelector/DistrictSelector';
 import LabelStepIndicator from '@/components/molecules/LabelStepIndicator';
 import StepNavigation from '@/components/molecules/StepNavigation';
+import { AlertModalState, ConfirmModalState } from '@/types/modal.type';
 
 export default function ComponentTest() {
   const [carouselStep, setCarouselStep] = useState<number>(0);
@@ -37,28 +38,38 @@ export default function ComponentTest() {
   const [dualRangeValue, setDualRangeValue] = useState<InputRangeState>([
     0, 100,
   ]);
-  const { openModal: openAlertModal } = useModal({
+
+  const { setModalState: setAlertModal, closeModal: closeAlertModal } =
+    useModal('Alert');
+  const alertModaContext: AlertModalState = {
+    isOpen: true,
     type: 'Alert',
-    modalProps: {
-      type: 'Alert',
-      title: '알림',
-      message: '이메일로 인증번호가 전송되었습니다.',
-      buttonContent: '확인',
-      onClickConfirm: () => alert('AlertModal is Popped!!'),
+    title: '알림',
+    message: '이메일로 인증번호가 전송되었습니다.',
+    buttonContent: '확인',
+    onClickConfirm: () => {
+      alert('AlertModal is Popped!!');
+      closeAlertModal();
     },
-  });
-  const { openModal: openConfirmModal } = useModal({
-    type: 'Confirm',
-    modalProps: {
-      type: 'Confim',
-      title: '친구 차단',
-      message: '선택한 유저를 차단하시겠습니까?',
-      confirmButtonContent: '차단',
-      cancelButtonContent: '취소',
-      onClickConfirm: () => alert('user is blocked!!✅'),
-      onClickCancel: () => {},
+  };
+  const { setModalState: setConfirmModal, closeModal: closeConfirmModal } =
+    useModal('Confirm');
+  const confirmModalContext: ConfirmModalState = {
+    isOpen: true,
+    type: 'Confim',
+    title: '친구 차단',
+    message: '선택한 유저를 차단하시겠습니까?',
+    confirmButtonContent: '차단',
+    cancelButtonContent: '취소',
+    onClickConfirm: () => {
+      alert('user is blocked!!✅');
+      closeConfirmModal();
     },
-  });
+    onClickCancel: () => {
+      closeConfirmModal();
+    },
+  };
+
   const labelStepContents = [
     {
       labelName: '집 유형, 매물 종류',
@@ -635,10 +646,17 @@ export default function ComponentTest() {
       <hr style={{ marginTop: '2rem', marginBottom: '2rem' }} />
       {/* Alert & Confirm & Profile Modal test */}
       <h1 className="text-Head2">ModalTest</h1>
-      <button className="mb-10" type="button" onClick={openAlertModal}>
+      <button
+        className="mb-10"
+        type="button"
+        onClick={() => setAlertModal(alertModaContext)}
+      >
         Alert modal 열기
       </button>
-      <button type="button" onClick={openConfirmModal}>
+      <button
+        type="button"
+        onClick={() => setConfirmModal(confirmModalContext)}
+      >
         Confirm modal 열기
       </button>
     </div>

--- a/src/components/templates/GlobalModal.tsx
+++ b/src/components/templates/GlobalModal.tsx
@@ -6,7 +6,7 @@ import ProfileModal from '@/components/organisms/modals/ProfileModal';
 import { GlobalModalAtom } from '@/stores/globalModal.store';
 
 export default function GlobalModal() {
-  const { modalType } = useRecoilValue(GlobalModalAtom);
+  const  modalType  = useRecoilValue(GlobalModalAtom);
 
   // eslint-disable-next-line react-refresh/only-export-components
   const TypesOfModals = {

--- a/src/components/templates/GlobalModal.tsx
+++ b/src/components/templates/GlobalModal.tsx
@@ -1,26 +1,12 @@
 import { useRecoilValue } from 'recoil';
-import { ReactNode } from 'react';
 
-import Container from '@/components/atoms/Container';
 import AlertModal from '@/components/organisms/modals/AlertModal';
 import ConfirmModal from '@/components/organisms/modals/ConfirmModal';
 import ProfileModal from '@/components/organisms/modals/ProfileModal';
 import { GlobalModalAtom } from '@/stores/globalModal.store';
 
-type ModalContainerType = {
-  children: ReactNode;
-};
-
-function ModalContainer({ children }: ModalContainerType) {
-  return (
-    <Container.FlexRow className="fixed left-0 top-0 z-50 h-[100vh] w-[100vw] items-center justify-center bg-[#6D6D6D]/50">
-      {children}
-    </Container.FlexRow>
-  );
-}
-
 export default function GlobalModal() {
-  const { modalType, isOpen } = useRecoilValue(GlobalModalAtom);
+  const { modalType } = useRecoilValue(GlobalModalAtom);
 
   // eslint-disable-next-line react-refresh/only-export-components
   const TypesOfModals = {
@@ -32,9 +18,5 @@ export default function GlobalModal() {
   const SelectedModal = TypesOfModals[modalType];
   console.log('SelectedModal', SelectedModal);
 
-  return isOpen ? (
-    <ModalContainer>
-      <SelectedModal />
-    </ModalContainer>
-  ) : null;
+  return <SelectedModal />;
 }

--- a/src/components/templates/GlobalModal.tsx
+++ b/src/components/templates/GlobalModal.tsx
@@ -16,7 +16,6 @@ export default function GlobalModal() {
   };
 
   const SelectedModal = TypesOfModals[modalType];
-  console.log('SelectedModal', SelectedModal);
 
   return <SelectedModal />;
 }

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,59 +1,28 @@
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import { useEffect } from 'react';
 
+import { ModalType } from '@/types/modal.type';
 import { GlobalModalAtom, ModalSelector } from '@/stores/globalModal.store';
-import {
-  ConfirmModalState,
-  ModalStateByType,
-  ModalType,
-} from '@/types/modal.type';
 
-type UseModalProps<T extends ModalType> = {
-  type: T;
-  modalProps: ModalStateByType[T];
-};
+export default function useModal<T extends ModalType>(modalType: T) {
+  const setGlobalModalState = useSetRecoilState(GlobalModalAtom);
+  const [modalState, setModalState] = useRecoilState(ModalSelector(modalType));
 
-// ! 나중에 modal을 연속적으로 띄우고 싶을 때 queue의 형태로 modal을 구현필요할 수도???
-export default function useModal<T extends ModalType>({
-  type,
-  modalProps,
-}: UseModalProps<T>) {
-  const [{ isOpen, modalType }, setGlobalModalState] =
-    useRecoilState(GlobalModalAtom);
-  const [modal, setModal] = useRecoilState(ModalSelector(type));
+  const openModal = () => setModalState(prev => ({ ...prev, isOpen: true }));
+  const closeModal = () => setModalState(prev => ({ ...prev, isOpen: false }));
+  const getModalState = () => modalState;
 
-  const openModal = () =>
-    setGlobalModalState(prev => ({ ...prev, isOpen: true }));
-  const closeModal = () =>
-    setGlobalModalState(prev => ({ ...prev, isOpen: false }));
-  const getModalState = () => modal;
-
+  // ! globalModal의 modalType에 따라 최종적으로 한 개의 modal(SelectedModal)이 되므로,
+  // ! type에 따른 modal의 state가 바뀔 때 GlobalModalState의 modalType을 변경해주어야 한다.
   useEffect(() => {
-    setGlobalModalState(prev => ({ ...prev, modalType: type }));
+    setGlobalModalState(prev => ({ ...prev, modalType }));
+  }, [modalState, modalType, setGlobalModalState]);
 
-    // ! closeModal과 같이 모든 button에 대한 기본 동작을 넣어주면된다.
-    // ! 추후, async후 modal이 닫히게 될 기능이 있다면 closeModal()을 function scope의
-    // ! 맨 하단에 위치
-    const nextModalProps = {
-      ...modalProps,
-      onClickConfirm: () => {
-        modalProps.onClickConfirm();
-        closeModal();
-      },
-    };
-
-    if (modalProps.type === 'Confim') {
-      (nextModalProps as ConfirmModalState).onClickCancel = () => {
-        modalProps.onClickCancel();
-        closeModal();
-      };
-    }
-    console.log('nextModalProps in useEffect 👇\n', nextModalProps);
-
-    setModal({ ...nextModalProps });
-  }, []);
-
-  console.log('console modal state =>', modal);
-
-  return { openModal, closeModal, getModalState, isModalOpen: isOpen === true };
+  return {
+    openModal,
+    closeModal,
+    getModalState,
+    setModalState,
+    isModalOpen: modalState.isOpen === true,
+  };
 }

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -15,7 +15,7 @@ export default function useModal<T extends ModalType>(modalType: T) {
   // ! globalModal의 modalType에 따라 최종적으로 한 개의 modal(SelectedModal)이 되므로,
   // ! type에 따른 modal의 state가 바뀔 때 GlobalModalState의 modalType을 변경해주어야 한다.
   useEffect(() => {
-    setGlobalModalState(prev => ({ ...prev, modalType }));
+    setGlobalModalState(modalType);
   }, [modalState, modalType, setGlobalModalState]);
 
   return {

--- a/src/stores/globalModal.store.ts
+++ b/src/stores/globalModal.store.ts
@@ -45,32 +45,31 @@ export const ConfirmModalAtom = atom<ConfirmModalState>({
 export const ProfileModalAtom = atom<ProfileModalState>({
   key: 'profileModalState',
   default: {
+    isOpen: false,
     type: 'Profile',
     onClickConfirm: () => {},
   },
 });
-export const ModalSelector = selectorFamily<
-  ModalStateByType[keyof ModalStateByType],
-  ModalType
->({
+
+export const ModalSelector = selectorFamily({
   key: 'modalPropsByType',
   get:
     <P extends ModalType>(modalType: P) =>
     ({ get }) => {
       switch (modalType) {
         case 'Alert':
-          return get(AlertModalAtom) as AlertModalState;
+          return get(AlertModalAtom) as ModalStateByType[P];
         case 'Confirm':
-          return get(ConfirmModalAtom) as ConfirmModalState;
+          return get(ConfirmModalAtom) as ModalStateByType[P];
         case 'Profile':
-          return get(ProfileModalAtom) as ProfileModalState;
+          return get(ProfileModalAtom) as ModalStateByType[P];
         default:
           errorSelector('Undefined cannot be a value of ModalType.');
-          return get(AlertModalAtom) as AlertModalState;
+          throw new Error('Undefined cannot be a value of ModalType.');
       }
     },
   set:
-    modalType =>
+    <P extends ModalType>(modalType: P) =>
     ({ set }, newModalState) => {
       switch (modalType) {
         case 'Alert':
@@ -84,8 +83,8 @@ export const ModalSelector = selectorFamily<
           break;
         default:
           // eslint-disable-next-line no-console
-          console.warn(`Received unexpected modal type: ${modalType}`);
           errorSelector(`Received unexpected modal type: ${modalType}`);
+          throw new Error(`Received unexpected modal type: ${modalType}`);
       }
     },
 });

--- a/src/stores/globalModal.store.ts
+++ b/src/stores/globalModal.store.ts
@@ -12,7 +12,6 @@ import {
 export const GlobalModalAtom = atom<GlobalModalState>({
   key: 'globalModalstate',
   default: {
-    isOpen: false,
     modalType: 'Alert',
   },
 });
@@ -20,6 +19,7 @@ export const GlobalModalAtom = atom<GlobalModalState>({
 export const AlertModalAtom = atom<AlertModalState>({
   key: 'alertModalState',
   default: {
+    isOpen: false,
     type: 'Alert',
     title: '',
     message: '',
@@ -31,6 +31,7 @@ export const AlertModalAtom = atom<AlertModalState>({
 export const ConfirmModalAtom = atom<ConfirmModalState>({
   key: 'confirmModalState',
   default: {
+    isOpen: false,
     type: 'Confim',
     title: '',
     message: '',

--- a/src/stores/globalModal.store.ts
+++ b/src/stores/globalModal.store.ts
@@ -3,7 +3,6 @@ import { atom, errorSelector, selectorFamily } from 'recoil';
 import {
   AlertModalState,
   ConfirmModalState,
-  // GlobalModalState,
   ModalStateByType,
   ModalType,
   ProfileModalState,

--- a/src/stores/globalModal.store.ts
+++ b/src/stores/globalModal.store.ts
@@ -3,17 +3,15 @@ import { atom, errorSelector, selectorFamily } from 'recoil';
 import {
   AlertModalState,
   ConfirmModalState,
-  GlobalModalState,
+  // GlobalModalState,
   ModalStateByType,
   ModalType,
   ProfileModalState,
 } from '@/types/modal.type';
 
-export const GlobalModalAtom = atom<GlobalModalState>({
+export const GlobalModalAtom = atom<ModalType>({
   key: 'globalModalstate',
-  default: {
-    modalType: 'Alert',
-  },
+  default: 'Alert'
 });
 
 export const AlertModalAtom = atom<AlertModalState>({

--- a/src/types/modal.type.ts
+++ b/src/types/modal.type.ts
@@ -1,9 +1,5 @@
 export type ModalType = 'Alert' | 'Confirm' | 'Profile';
 
-// export type GlobalModalState = {
-//   modalType: ModalType;
-// };
-
 export type ModalStateByType = {
   Alert: AlertModalState;
   Confirm: ConfirmModalState;

--- a/src/types/modal.type.ts
+++ b/src/types/modal.type.ts
@@ -1,7 +1,6 @@
 export type ModalType = 'Alert' | 'Confirm' | 'Profile';
 
 export type GlobalModalState = {
-  isOpen: boolean;
   modalType: ModalType;
 };
 
@@ -12,6 +11,7 @@ export type ModalStateByType = {
 };
 
 export type AlertModalState = {
+  isOpen: boolean;
   type: 'Alert';
   title: string;
   message: string;
@@ -20,6 +20,7 @@ export type AlertModalState = {
 };
 
 export type ConfirmModalState = {
+  isOpen: boolean;
   type: 'Confim';
   title: string;
   message: string;
@@ -30,6 +31,7 @@ export type ConfirmModalState = {
 };
 
 export type ProfileModalState = {
+  isOpen: boolean;
   type: 'Profile';
   onClickConfirm: () => void;
 };

--- a/src/types/modal.type.ts
+++ b/src/types/modal.type.ts
@@ -1,8 +1,8 @@
 export type ModalType = 'Alert' | 'Confirm' | 'Profile';
 
-export type GlobalModalState = {
-  modalType: ModalType;
-};
+// export type GlobalModalState = {
+//   modalType: ModalType;
+// };
 
 export type ModalStateByType = {
   Alert: AlertModalState;


### PR DESCRIPTION
## #️⃣ issue-9
Resolves(이슈해결)

## 📝 개요(이미지 첨부 선택)
*<!-- 이슈에 대해 어떻게, 무엇을, 왜 수정했는지 작성해주세요. -->*
여러 모달 선언시 최종적으로 하나의 모달만이 rendering되는 문제를 해결함. 해결한 과정은 아래 `1, 2, 3, 4`과정 참고

![issue-9](https://github.com/house-mate-connect/house-connect/assets/52829400/ac31cd5d-d62d-487b-801f-3e135b47938f)



### 1. 관련 state(isOpen)을 자체 component내로 위치
기존에 GlobalModal이 관리하던 isOpen state를 modal이 관리하도록 하여 `GlobalModal과 결합도를 낮추고` isOpen과 `자체 modal Component와의 응집도를 향상`시킴.

isOpen의 값에 따라 ModalConainer(backdrop)도 modal component와 연관시킴

Backdrop 효과를 주며 modal을 감싸는 component를 따로 생성(ModalContainer)

```typescript
// src/components/organisms/modals/ModalContainer.tsx

export default function ModalContainer({ children }: ModalContainerType) {
  return (
     // backdrop에 관련된 JSX
  );
}
```

isOpen을 자체내로 이동시키고 isOpen상태에 따라 modal을 보여줄수 있게 개선
```typescript
// src/components/organisms/modals/AlertModal.tsx
export default function AlertModal() {
  const { 
    ...//, 
    isOpen // ✅
  } = useRecoilValue(AlertModalAtom);
    
  return isOpen ? (AlertModal JSX) : null; // ✅
}

// src/components/organisms/modals/ConfirmModal.tsx
export default function ConfirmModal() {
  const { 
    ...//, 
    isOpen // ✅
  } = useRecoilValue(AlertModalAtom);
    
  return isOpen ? (ConfirmModal JSX) : null; // ✅
}
```

### 2. modal을 사용하는 시점에 state를 mutate하여 동적으로 modal component 생성
```typescript
// src/components/templates/GlobalModal.tsx

export default function GlobalModal() {
  const  modalType  = useRecoilValue(GlobalModalAtom);

  const TypesOfModals = {
    Alert: AlertModal,
    Confirm: ConfirmModal,
    Profile: ProfileModal,
  };

  const SelectedModal = TypesOfModals[modalType];

  return <SelectedModal />;
}

```

```typescript
// src/hooks/useModal.tsx

export default function useModal<T extends ModalType>(modalType: T) {
  const setGlobalModalState = useSetRecoilState(GlobalModalAtom);
  const [modalState, setModalState] = useRecoilState(ModalSelector(modalType));
  ... // 

  // 👇 modal을 사용하는 시점(modal state mutate)에 맞추어 modalType을 변경함으로써 
  // 위의 GlobalModal내의 SelectedModal을 동적으로 할당
  useEffect(() => {
    setGlobalModalState(modalType);
  }, [modalState, modalType, setGlobalModalState]); 
  
  ... //
}
```

### 3. modalType에 따라 modal state를 정확하게 추론하여 DX를 개선
**AS-IS**
```typescript
// src/stores/globalModal.store.ts

export const ModalSelector = selectorFamily({
  key: 'modalPropsByType',
  get:
    <P extends ModalType>(modalType: P) =>
    ({ get }) => {
      switch (modalType) {
        case 'Alert':
          return get(AlertModalAtom) as AlertModalState; // ❌
        case 'Confirm':
          return get(ConfirmModalAtom) as ConfirmModalState; // ❌
        case 'Profile':
          return get(ProfileModalAtom) as ProfileModalState; // ❌
          ... //
      }
    },
   ... //
});
```

아래와 같이 modal 및 state setter의 type을 정확하게 추론하지 못 하는 문제.

<img width="1089" alt="327496275-fe020d61-bdd1-4d56-80eb-94d26ff0ab26" src="https://github.com/house-mate-connect/house-connect/assets/52829400/f0d23f09-f6bb-4576-b180-c5613a87772f">


**TO-BE**
```typescript
// src/stores/globalModal.store.ts

export const ModalSelector = selectorFamily({
  key: 'modalPropsByType',
  get:
    <P extends ModalType>(modalType: P) =>
    ({ get }) => {
      switch (modalType) {
        case 'Alert':
          return get(AlertModalAtom) as ModalStateByType[P]; // ✅ 동적 타입으로 통일
        case 'Confirm':
          return get(ConfirmModalAtom) as ModalStateByType[P];  // ✅ 동적 타입으로 통일
        case 'Profile':
          return get(ProfileModalAtom) as ModalStateByType[P];  // ✅ 동적 타입으로 통일
        ... //
      }
    },
   ... //
});
```

파라미터를 통해 P 타입을 추론하는 generic을 사용하고 get의 return type을 ModalStateByType[P]로 통일하여
동적으로 타입을 추론할 수 있게 함.

<img width="727" alt="image" src="https://github.com/house-mate-connect/house-connect/assets/52829400/96500ac6-33e8-405b-9b0b-9c78f255ffcd">

### 4. instance화된 modal component가 공유하는 state로 생기는 문제를 modal 사용 시점에 state를 mutate하여 해결
- 고도의 추상화 문제를 state mutate시 관련 state를 meta 정보로서 활용하여 modal에 대한 정보를 파악할 수 있게 함.
- modal state에 따라 SelectedModal또한 업데이트하여 동기화시킴

```typescript
// src/hooks/useModal.tsx

export default function useModal<T extends ModalType>(modalType: T) {
  const setGlobalModalState = useSetRecoilState(GlobalModalAtom);
  const [modalState, setModalState] = useRecoilState(ModalSelector(modalType));
  ... // 

  // 👇 modal을 사용하는 시점(modal state mutate)에 맞추어 modalType을 변경함으로써 
  // 위의 GlobalModal내의 SelectedModal을 동적으로 할당
  useEffect(() => {
    setGlobalModalState(modalType);
  }, [modalState, modalType, setGlobalModalState]); // ✅ modal state에 따라 modalType도 mutate하여 SelectedModal을 재할당
  
  ... //
}
```

```typescript
// 사용 사례
  const { setModalState: setAlertModal, closeModal: closeAlertModal } =
    useModal('Alert');
  const alertModaContext: AlertModalState = {
    isOpen: true,
    type: 'Alert',
    title: '알림',
    message: '이메일로 인증번호가 전송되었습니다.',
    buttonContent: '확인',
    onClickConfirm: () => {
      alert('AlertModal is Popped!!');
      closeAlertModal();
    },
  };

  return (
    ... // 
    <button
        className="mb-10"
        type="button"
        onClick={() => setAlertModal(alertModaContext)} // ✅ modal이 필요한 시점에 state mutate
      >
        Alert modal 열기
      </button>
  )

```

## ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [ ] 모든 팀원이 PR에 대한 리뷰를 진행했습니다.
- [x] 이 코드 변경 사항은 기존 기능에 영향을 주지 않나요?
- [x] 팀원이 이해할 수 있도록 충분한 주석 및 코드 일관성을 준수했나요? (변수명, 함수명, 클래스명, 가독성 등)

## 💁‍♂️ PR 추가 정보
*<!-- PR과 관련된 기타 정보(E.G 개선사항, 리뷰어가 봐주었으면 하는 점)가 있다면 여기에 적어주세요. -->*
어느 컴포넌트에서든 modal에 접근할 수 있게 만들기 위해 modal state를 전역 상태로 관리하지만, 이로 인해 instance화된 modal component가 공유하는 state로 생기는 문제로 인해 아래와 같은 문제들이 발생할 수 있다.

1. `상태 오염(State Pollution)`: 여러 모달이 동일한 상태를 공유할 경우, `한 모달에서의 상태 변경이 다른 모달에도 영향을 미칠 수 있음`.
2. `동기화 문제(Synchronization Issues)`: 상태 업데이트의 `동기화를 관리하는 것이 복잡`해짐. 또한 한 인스턴스에서의 상태 변경이 다른 인스턴스에 실시간으로 반영되어야 할 필요가 있을 때 문제가 발생.
3. `상태 관리 복잡성(State Management Complexity)`: 모든 인스턴스가 접근 가능한 `중앙 집중식 상태`를 유지하는 것은 상태 관리 로직을 복잡하게 만들 수 있으며 상태 추적을 어렵게 함.

이에 관련하여 추후 개선이 필요해 보임.