### PR TITLE
[Merge] HC-98-User-Password-Reset to Dev

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -10,6 +10,8 @@ import SignUp from '@/components/pages/SignUp';
 import About from '@/components/pages/About';
 import SignUpProfileOutro from '@/components/pages/SignUpProfileOutro';
 import HouseRegister from '@/components/pages/HouseRegister';
+import SignPasswordReset from '@/components/pages/SignPasswordReset';
+import SignUpdatePassword from '@/components/pages/SignUpdatePassword';
 
 const router = createBrowserRouter([
   {
@@ -54,6 +56,14 @@ const router = createBrowserRouter([
           {
             path: 'up',
             element: <SignUp />,
+          },
+          {
+            path: 'password',
+            element: <SignPasswordReset />,
+          },
+          {
+            path: 'update-password',
+            element: <SignUpdatePassword />,
           },
         ],
       },

--- a/src/components/pages/SignPasswordReset.tsx
+++ b/src/components/pages/SignPasswordReset.tsx
@@ -1,0 +1,5 @@
+import SignPasswordResetTemplate from '@/components/templates/SignPasswordReset.template';
+
+export default function SignPasswordReset() {
+  return <SignPasswordResetTemplate />;
+}

--- a/src/components/pages/SignUp.tsx
+++ b/src/components/pages/SignUp.tsx
@@ -32,7 +32,7 @@ export default function SignUp() {
         className="size-[2.75rem] rounded-full"
       />
       <Container.FlexCol className="gap-[3.5rem]">
-        <Typography.Head2>회원가입</Typography.Head2>
+        <Typography.Head2 className="text-brown">회원가입</Typography.Head2>
         <Container className="w-full">
           <Carousel order={currentStep}>
             <SignUpIntroTemplate1 step={setCurrentStep} />

--- a/src/components/pages/SignUpdatePassword.tsx
+++ b/src/components/pages/SignUpdatePassword.tsx
@@ -1,0 +1,5 @@
+import SignUpdatePasswordTemplate from '@/components/templates/SignUpdatePassword.template';
+
+export default function SignUpdatePassword() {
+  return <SignUpdatePasswordTemplate />;
+}

--- a/src/components/templates/SignInTemplate.tsx
+++ b/src/components/templates/SignInTemplate.tsx
@@ -136,7 +136,7 @@ export default function SignInTemplate() {
               <div className="mt-4 flex flex-row-reverse gap-2">
                 <Link to="/sign/up">회원가입</Link>
                 <Divider.Row />
-                <Link to="/sign/up">비밀번호 찾기</Link>
+                <Link to="/sign/password">비밀번호 찾기</Link>
               </div>
               <Button.Fill
                 type="submit"

--- a/src/components/templates/SignPasswordReset.template.tsx
+++ b/src/components/templates/SignPasswordReset.template.tsx
@@ -1,0 +1,64 @@
+import { FormProvider, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useNavigate } from 'react-router-dom';
+
+import Container from '@/components/atoms/Container';
+import Typography from '@/components/atoms/Typography';
+import Button from '@/components/atoms/Button';
+import FormItem from '@/components/molecules/FormItem';
+import { SignPasswordReset, SignPasswordResetType } from '@/types/auth.type';
+import { useSignPasswordReset } from '@/hooks/useSignPasswordReset';
+import IconButton from '@/components/molecules/IconButton';
+
+export default function SignPasswordResetTemplate() {
+  const navigate = useNavigate();
+  const Form = FormProvider;
+  const form = useForm<SignPasswordResetType>({
+    resolver: zodResolver(SignPasswordReset),
+  });
+  const { passwordReset, isPending } = useSignPasswordReset();
+
+  const onClickPasswordReset = (data: SignPasswordResetType) => {
+    passwordReset(data);
+  };
+
+  const onClickPrevButton = () => {
+    navigate('/sign/in');
+  };
+  return (
+    <Container.FlexCol className="w-full gap-[2.5rem]">
+      <IconButton.Ghost
+        onClick={onClickPrevButton}
+        iconType="back"
+        iconClassName="mx-auto"
+        className="size-[2.75rem] rounded-full"
+      />
+      <Container.FlexCol className="gap-[3.5rem]">
+        <Typography.Head2 className="text-brown">
+          비밀번호 초기화
+        </Typography.Head2>
+        <Container className="w-full">
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onClickPasswordReset)}>
+              <FormItem.TextField
+                labelName="이메일"
+                name="email"
+                placeholder="이메일 입력"
+                inputStyle="w-full bg-transparent mt-[1rem]"
+              />
+              <Button.Fill
+                type="submit"
+                className="mt-[3.25rem] w-full rounded-[10px]"
+                disabled={isPending}
+              >
+                <Typography.P3 className="mx-auto my-[1rem] text-[#F4E7DB]">
+                  비밀번호 초기화
+                </Typography.P3>
+              </Button.Fill>
+            </form>
+          </Form>
+        </Container>
+      </Container.FlexCol>
+    </Container.FlexCol>
+  );
+}

--- a/src/components/templates/SignUpdatePassword.template.tsx
+++ b/src/components/templates/SignUpdatePassword.template.tsx
@@ -1,0 +1,83 @@
+import { FormProvider, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Link } from 'react-router-dom';
+import { useState } from 'react';
+
+import Container from '@/components/atoms/Container';
+import FormItem from '@/components/molecules/FormItem';
+import Button from '@/components/atoms/Button';
+import Typography from '@/components/atoms/Typography';
+import { SignUpdatePassword, SignUpdatePasswordType } from '@/types/auth.type';
+import IconButton from '@/components/molecules/IconButton';
+
+export default function SignUpdatePasswordTemplate() {
+  const [showPassword, setShowPassword] = useState(false);
+  const Form = FormProvider;
+  const form = useForm<SignUpdatePasswordType>({
+    resolver: zodResolver(SignUpdatePassword),
+  });
+  const onClickShowPassword = () => setShowPassword(prev => !prev);
+  const onSubmit = (data: SignUpdatePasswordType) => {
+    console.log(data);
+  };
+  return (
+    <Container.FlexCol className="w-full gap-[2.5rem]">
+      <Container.FlexCol className="gap-[3.5rem]">
+        <Typography.Head2 className="text-brown">
+          비밀번호 변경
+        </Typography.Head2>
+        <Container className="w-full">
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)}>
+              <Container.FlexCol className="gap-[1.625rem]">
+                <Container className="relative">
+                  <FormItem.TextField
+                    labelName="비밀번호"
+                    type={showPassword ? 'text' : 'password'}
+                    name="password"
+                    placeholder="비밀번호 입력"
+                    inputStyle="w-full mt-[1rem]"
+                  />
+                  <IconButton.Ghost
+                    className="absolute bottom-[44px] right-[13px] top-[53px]"
+                    iconType={showPassword ? 'visible' : 'invisible'}
+                    onClick={onClickShowPassword}
+                  />
+                </Container>
+                <Container className="relative">
+                  <FormItem.TextField
+                    labelName="비밀번호 재입력"
+                    type={showPassword ? 'text' : 'password'}
+                    name="confirmPassword"
+                    placeholder="비밀번호 입력"
+                    inputStyle="w-full mt-[1rem]"
+                  />
+                  <IconButton.Ghost
+                    className="absolute bottom-[44px] right-[13px] top-[53px]"
+                    iconType={showPassword ? 'visible' : 'invisible'}
+                    onClick={onClickShowPassword}
+                  />
+                </Container>
+              </Container.FlexCol>
+              <Button.Fill
+                type="submit"
+                className="mt-[3.25rem] w-full rounded-[10px]"
+              >
+                <Typography.P3 className="mx-auto my-[1rem] text-[#F4E7DB]">
+                  확인
+                </Typography.P3>
+              </Button.Fill>
+              <Link to="/sign/in" className="w-full">
+                <Button.Outline className="mx-auto my-[1rem] w-full rounded-[10px]">
+                  <Typography.P3 className="mx-auto my-[1rem] text-brown">
+                    로그인 페이지로 이동
+                  </Typography.P3>
+                </Button.Outline>
+              </Link>
+            </form>
+          </Form>
+        </Container>
+      </Container.FlexCol>
+    </Container.FlexCol>
+  );
+}

--- a/src/components/templates/SignUpdatePassword.template.tsx
+++ b/src/components/templates/SignUpdatePassword.template.tsx
@@ -9,6 +9,7 @@ import Button from '@/components/atoms/Button';
 import Typography from '@/components/atoms/Typography';
 import { SignUpdatePassword, SignUpdatePasswordType } from '@/types/auth.type';
 import IconButton from '@/components/molecules/IconButton';
+import { useSignUpdatePassword } from '@/hooks/useSignPasswordReset';
 
 export default function SignUpdatePasswordTemplate() {
   const [showPassword, setShowPassword] = useState(false);
@@ -17,8 +18,9 @@ export default function SignUpdatePasswordTemplate() {
     resolver: zodResolver(SignUpdatePassword),
   });
   const onClickShowPassword = () => setShowPassword(prev => !prev);
+  const { updatePassword, isPending } = useSignUpdatePassword();
   const onSubmit = (data: SignUpdatePasswordType) => {
-    console.log(data);
+    updatePassword(data);
   };
   return (
     <Container.FlexCol className="w-full gap-[2.5rem]">
@@ -37,6 +39,7 @@ export default function SignUpdatePasswordTemplate() {
                     name="password"
                     placeholder="비밀번호 입력"
                     inputStyle="w-full mt-[1rem]"
+                    disabled={isPending}
                   />
                   <IconButton.Ghost
                     className="absolute bottom-[44px] right-[13px] top-[53px]"
@@ -51,6 +54,7 @@ export default function SignUpdatePasswordTemplate() {
                     name="confirmPassword"
                     placeholder="비밀번호 입력"
                     inputStyle="w-full mt-[1rem]"
+                    disabled={isPending}
                   />
                   <IconButton.Ghost
                     className="absolute bottom-[44px] right-[13px] top-[53px]"
@@ -62,13 +66,17 @@ export default function SignUpdatePasswordTemplate() {
               <Button.Fill
                 type="submit"
                 className="mt-[3.25rem] w-full rounded-[10px]"
+                disabled={isPending}
               >
                 <Typography.P3 className="mx-auto my-[1rem] text-[#F4E7DB]">
                   확인
                 </Typography.P3>
               </Button.Fill>
               <Link to="/sign/in" className="w-full">
-                <Button.Outline className="mx-auto my-[1rem] w-full rounded-[10px]">
+                <Button.Outline
+                  className="mx-auto my-[1rem] w-full rounded-[10px]"
+                  disabled={isPending}
+                >
                   <Typography.P3 className="mx-auto my-[1rem] text-brown">
                     로그인 페이지로 이동
                   </Typography.P3>

--- a/src/hooks/useSignPasswordReset.ts
+++ b/src/hooks/useSignPasswordReset.ts
@@ -1,0 +1,50 @@
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+
+import {
+  SignPasswordResetType,
+  SignUpdatePasswordType,
+} from '@/types/auth.type';
+import { supabase } from '@/libs/supabaseClient';
+import { createToast, errorToast, successToast } from '@/libs/toast';
+
+export const useSignPasswordReset = () => {
+  const { mutate: passwordReset, isPending } = useMutation({
+    mutationFn: async (payload: SignPasswordResetType) => {
+      const { error } = await supabase.auth.resetPasswordForEmail(
+        payload.email,
+        {
+          redirectTo: 'http://localhost:5173/sign/update-password',
+        },
+      );
+      if (error) throw new Error(error.message);
+    },
+    onMutate: () =>
+      createToast('passwordReset', '초기화 요청을 보내는 중입니다...'),
+    onSuccess: () => successToast('passwordReset', '이메일을 확인해주세요.'),
+    onError: () => errorToast('passwordReset', '요청에 실패했습니다.'),
+  });
+  return { passwordReset, isPending };
+};
+
+export const useSignUpdatePassword = () => {
+  const navigate = useNavigate();
+  const { mutate: updatePassword, isPending } = useMutation({
+    mutationFn: async (payload: Pick<SignUpdatePasswordType, 'password'>) => {
+      const { error } = await supabase.auth.updateUser({
+        password: payload.password,
+      });
+      if (error) throw new Error(error.message);
+    },
+    onMutate: () =>
+      createToast('passwordUpdate', '비밀번호를 변경 중입니다...'),
+    onSuccess: () => {
+      successToast('passwordUpdate', '비밀번호 변경에 성공했습니다.');
+      navigate('/sign/in');
+    },
+    onError: () => {
+      errorToast('passwordUpdate', '비밀번호 변경에 실패했습니다.');
+    },
+  });
+  return { updatePassword, isPending };
+};

--- a/src/types/auth.type.ts
+++ b/src/types/auth.type.ts
@@ -182,3 +182,23 @@ export type GoogleOAuthType = {
     },
   ];
 };
+
+export const SignPasswordReset = z.object({
+  email: z
+    .string({ required_error: '이메일을 입력해주세요.' })
+    .email({ message: '이메일 형식으로 입력해주세요.' }),
+});
+
+export type SignPasswordResetType = z.infer<typeof SignPasswordReset>;
+
+export const SignUpdatePassword = z
+  .object({
+    password: PasswordValidate,
+    confirmPassword: PasswordValidate,
+  })
+  .refine(data => data.password === data.confirmPassword, {
+    message: '비밀번호가 일치하지 않습니다.',
+    path: ['confirmPassword'],
+  });
+
+export type SignUpdatePasswordType = z.infer<typeof SignUpdatePassword>;


### PR DESCRIPTION
## 📝 개요(이미지 첨부 선택)
*<!-- 이슈에 대해 어떻게, 무엇을, 왜 수정했는지 작성해주세요. -->*
### 패스워드 초기화하는 기능 및 페이지 추가

페이지는 2가지로 분류

- 이메일을 입력하여 비밀번호 초기화 요청할 수 있는 페이지
- 실제 비밀번호를 변경하는 페이지

### Flow
이메일을 입력하고 초기화 요청 ->
요청한 이메일로 비밀번호를 초기화 할 수 있는 페이지 링크가 담긴 메일 발송 ->
유저가 해당 링크를 클릭하여 패스워드 변경 페이지로 이동 ->
패스워드 변경 요청 후 완료 후 로그인 페이지로 이동

## 작업 내용

### 1. 페이지 UI
#### - /sign/password
![image](https://github.com/house-mate-connect/house-connect/assets/155633601/ab8f7ffc-efb2-4c29-ba23-0281cf8fa48f)
#### - /sign/update-password
![image](https://github.com/house-mate-connect/house-connect/assets/155633601/3dbfe919-2b58-4c53-94a9-6bb3f1c88eda)

### 2. 라우터 생성
sign 레이아웃을 동일하게 적용하여 `/sign/...` 로 구성
```tsx
        path: 'sign',
        element: <SignLayoutTemplate />,
        children: [
          ...
          {
            path: 'password',
            element: <SignPasswordReset />,
          },
          {
            path: 'update-password',
            element: <SignUpdatePassword />,
          },
```

### 3. 검증 및 타입 정의(Zod)
`/sign/password` (패스워드 초기화 요청) 관련
```ts
export const SignPasswordReset = z.object({
  email: z
    .string({ required_error: '이메일을 입력해주세요.' })
    .email({ message: '이메일 형식으로 입력해주세요.' }),
});

export type SignPasswordResetType = z.infer<typeof SignPasswordReset>;
```

`/sign/update-password` (실제 패스워드 변경) 관련
```ts
const PasswordValidate = z
  .string({ required_error: '비밀번호를 입력해주세요.' })
  .min(8, {
    message: '영문, 숫자, 특수기호를 포함하여 8자리 이상 입력해주세요.',
  })
  .regex(/^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$/, {
    message: '영문, 숫자, 특수기호를 포함하여 8자리 이상 입력해주세요.',
  });

export const SignUpdatePassword = z
  .object({
    password: PasswordValidate,
    confirmPassword: PasswordValidate,
  })
  .refine(data => data.password === data.confirmPassword, {
    message: '비밀번호가 일치하지 않습니다.',
    path: ['confirmPassword'],
  });

export type SignUpdatePasswordType = z.infer<typeof SignUpdatePassword>;
```
### 4. 초기화 로직

```ts
supabase.auth.resetPasswordForEmail(email, { redirectTo: '${사이트 URL}/sign/update-password'})
```
redirectTo를 작성하여 사용자가 메일로 받은 링크를 통해 패스워드 변경 페이지로 이동
```ts
supabase.auth.updateUser({ password: password})
...
navigate('/sign/in')
```
updateUser를 통해 비밀번호 수정 후 로그인 페이지로 이동

## ✅ PR 유형
어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [X] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.  
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [ ] 모든 팀원이 PR에 대한 리뷰를 진행했습니다.
- [X] 이 코드 변경 사항은 기존 기능에 영향을 주지 않나요?
- [ ] 팀원이 이해할 수 있도록 충분한 주석 및 코드 일관성을 준수했나요? (변수명, 함수명, 클래스명, 가독성 등)

## 💁‍♂️ PR 추가 정보
*<!-- PR과 관련된 기타 정보(E.G 개선사항, 리뷰어가 봐주었으면 하는 점)가 있다면 여기에 적어주세요. -->*
### URL 생성 후 ${사이트 URL}을 변경
현재 http://localhost:5173으로 작성