### PR TITLE
[Merge] HC-108-SignUp-Split-Page To HC-107-OAuth-Name-Birth

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -57,7 +57,7 @@ const router = createBrowserRouter([
             path: 'up',
             element: <SignUp />,
             children: [
-              { path: 'email', element: <SignUpEmail /> },
+              { index: true, element: <SignUpEmail /> },
               { path: 'info', element: <SignUpInfo /> },
             ],
           },

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -10,6 +10,8 @@ import SignUp from '@/components/pages/SignUp';
 import About from '@/components/pages/About';
 import SignUpProfileOutro from '@/components/pages/SignUpProfileOutro';
 import HouseRegister from '@/components/pages/HouseRegister';
+import SignUpEmail from '@/components/pages/SignUpEmail';
+import SignUpInfo from '@/components/pages/SignUpInfo';
 
 const router = createBrowserRouter([
   {
@@ -54,6 +56,10 @@ const router = createBrowserRouter([
           {
             path: 'up',
             element: <SignUp />,
+            children: [
+              { path: 'email', element: <SignUpEmail /> },
+              { path: 'info', element: <SignUpInfo /> },
+            ],
           },
         ],
       },

--- a/src/components/molecules/FormItem.tsx
+++ b/src/components/molecules/FormItem.tsx
@@ -42,6 +42,7 @@ FormItem.Password = function FormItemPassword<T extends FieldValues>(
         {...others}
       />
       <IconButton.Ghost
+        tabIndex={-1}
         className="absolute bottom-[44px] right-[13px] top-[53px]"
         iconType={isVisible ? 'visible' : 'invisible'}
         onClick={onClickVisible}

--- a/src/components/pages/SignUp.tsx
+++ b/src/components/pages/SignUp.tsx
@@ -1,21 +1,16 @@
-import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
+import { Outlet, useNavigate } from 'react-router-dom';
 
-import Carousel from '@/components/organisms/Carousel';
-import SignUpIntroTemplate1 from '@/components/templates/SignUpIntroTemplate1';
-import SignUpIntroTemplate2 from '@/components/templates/SignUpIntroTemplate2';
 import Container from '@/components/atoms/Container';
 import Typography from '@/components/atoms/Typography';
 import IconButton from '@/components/molecules/IconButton';
 import { supabase } from '@/libs/supabaseClient';
 
 export default function SignUp() {
-  const [currentStep, setCurrentStep] = useState(0);
   const navigate = useNavigate();
 
   const onClickPrevButton = () => {
-    if (currentStep === 0) navigate('/sign/in');
-    else setCurrentStep(prev => prev - 1);
+    navigate('/sign/in');
   };
   useEffect(() => {
     supabase.auth.onAuthStateChange(async event => {
@@ -34,10 +29,7 @@ export default function SignUp() {
       <Container.FlexCol className="gap-[3.5rem]">
         <Typography.Head2>회원가입</Typography.Head2>
         <Container className="w-full">
-          <Carousel order={currentStep}>
-            <SignUpIntroTemplate1 step={setCurrentStep} />
-            <SignUpIntroTemplate2 />
-          </Carousel>
+          <Outlet />
         </Container>
       </Container.FlexCol>
     </Container.FlexCol>

--- a/src/components/pages/SignUpEmail.tsx
+++ b/src/components/pages/SignUpEmail.tsx
@@ -1,0 +1,5 @@
+import SignUpEmailTemplate from '@/components/templates/SignUpEmail.template';
+
+export default function SignUpEmail() {
+  return <SignUpEmailTemplate />;
+}

--- a/src/components/pages/SignUpInfo.tsx
+++ b/src/components/pages/SignUpInfo.tsx
@@ -1,0 +1,5 @@
+import SignUpInfoTemplate from '@/components/templates/SignUpInfo.template';
+
+export default function SignUpInfo() {
+  return <SignUpInfoTemplate />;
+}

--- a/src/components/templates/SignLayout.template.tsx
+++ b/src/components/templates/SignLayout.template.tsx
@@ -1,20 +1,10 @@
-import { Outlet, useNavigate } from 'react-router-dom';
-import { useEffect } from 'react';
-import { useRecoilValue } from 'recoil';
+import { Outlet } from 'react-router-dom';
 
 import cn from '@/libs/cn';
 import Container from '@/components/atoms/Container';
 import Icon from '@/components/atoms/Icon';
-import { UserAtom } from '@/stores/auth.store';
 
 export default function SignLayoutTemplate() {
-  const navigate = useNavigate();
-  const user = useRecoilValue(UserAtom);
-  useEffect(() => {
-    if (user) {
-      navigate('/');
-    }
-  }, [user]);
   return (
     <>
       <Container

--- a/src/components/templates/SignUpEmail.template.tsx
+++ b/src/components/templates/SignUpEmail.template.tsx
@@ -1,11 +1,10 @@
 import { FormProvider, useForm, SubmitHandler } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import { useState } from 'react';
 
-import { SignUpEmailUserAtom, ShowVerificationAtom } from '@/stores/sign.store';
+import { ShowVerificationAtom } from '@/stores/sign.store';
 import {
-  EmailAuthType,
   SignUpEmail,
   SignUpEmailType,
   VerifyEmailType,
@@ -23,8 +22,6 @@ export default function SignUpEmailTemplate() {
   });
   const [passwordVisible, setPasswordVisible] = useState(false);
   const showVerification = useRecoilValue(ShowVerificationAtom);
-  const [signUpEmailUser, setSignUpEmailUser] =
-    useRecoilState(SignUpEmailUserAtom);
 
   const { signUpEmail, isSignUpEmail } = useSignUpEmail();
   const { verifyEmail, isVerifyEmail } = useVerifyEmail({
@@ -36,15 +33,8 @@ export default function SignUpEmailTemplate() {
 
   const isPending = isSignUpEmail || isVerifyEmail;
 
-  const onSubmitSignUp = async (formData: EmailAuthType) => {
-    if (signUpEmailUser.birth !== 0 && signUpEmailUser.gender !== 0) {
-      setSignUpEmailUser(prev => ({
-        ...prev,
-        email: formData.email,
-        password: formData.password,
-      }));
-      signUpEmail();
-    }
+  const onSubmitSignUp = async (formData: SignUpEmailType) => {
+    signUpEmail(formData);
   };
 
   const onSubmitVerify = async (formData: VerifyEmailType) => {
@@ -53,7 +43,7 @@ export default function SignUpEmailTemplate() {
 
   const onSubmit: SubmitHandler<SignUpEmailType> = data =>
     !showVerification
-      ? onSubmitSignUp(data as EmailAuthType)
+      ? onSubmitSignUp(data as SignUpEmailType)
       : onSubmitVerify(data as VerifyEmailType);
 
   return (

--- a/src/components/templates/SignUpEmail.template.tsx
+++ b/src/components/templates/SignUpEmail.template.tsx
@@ -6,8 +6,8 @@ import { useState } from 'react';
 import { SignUpEmailUserAtom, ShowVerificationAtom } from '@/stores/sign.store';
 import {
   EmailAuthType,
-  SignUpFormData2,
-  SignUpFormData2Type,
+  SignUpEmail,
+  SignUpEmailType,
   VerifyEmailType,
 } from '@/types/auth.type';
 import Button from '@/components/atoms/Button';
@@ -16,10 +16,10 @@ import Typography from '@/components/atoms/Typography';
 import FormItem from '@/components/molecules/FormItem';
 import { useSignUpEmail, useVerifyEmail } from '@/hooks/useSign';
 
-export default function SignUpIntroTemplate2() {
+export default function SignUpEmailTemplate() {
   const Form = FormProvider;
-  const form = useForm<SignUpFormData2Type>({
-    resolver: zodResolver(SignUpFormData2),
+  const form = useForm<SignUpEmailType>({
+    resolver: zodResolver(SignUpEmail),
   });
   const [passwordVisible, setPasswordVisible] = useState(false);
   const showVerification = useRecoilValue(ShowVerificationAtom);
@@ -51,7 +51,7 @@ export default function SignUpIntroTemplate2() {
     verifyEmail(formData);
   };
 
-  const onSubmit: SubmitHandler<SignUpFormData2Type> = data =>
+  const onSubmit: SubmitHandler<SignUpEmailType> = data =>
     !showVerification
       ? onSubmitSignUp(data as EmailAuthType)
       : onSubmitVerify(data as VerifyEmailType);
@@ -115,7 +115,7 @@ export default function SignUpIntroTemplate2() {
               disabled={isPending}
             >
               <Typography.P3 className="mx-auto my-[1rem] text-[#F4E7DB]">
-                확인
+                다음
               </Typography.P3>
             </Button.Fill>
           )}

--- a/src/components/templates/SignUpInfo.template.tsx
+++ b/src/components/templates/SignUpInfo.template.tsx
@@ -1,5 +1,4 @@
 import { FormProvider, useForm } from 'react-hook-form';
-import { Dispatch, SetStateAction } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { zodResolver } from '@hookform/resolvers/zod';
 
@@ -8,28 +7,22 @@ import Typography from '@/components/atoms/Typography';
 import Button from '@/components/atoms/Button';
 import { SignUpEmailUserAtom } from '@/stores/sign.store';
 import FormItem from '@/components/molecules/FormItem';
-import { SignUpFormData1, SignUpFormData1Type } from '@/types/auth.type';
+import { SignUpInfo, SignUpInfoType } from '@/types/auth.type';
 
-export default function SignUpIntroTemplate1({
-  step,
-}: {
-  step: Dispatch<SetStateAction<number>>;
-}) {
+export default function SignUpInfoTemplate() {
   const Form = FormProvider;
-  const form = useForm<SignUpFormData1Type>({
-    resolver: zodResolver(SignUpFormData1),
+  const form = useForm<SignUpInfoType>({
+    resolver: zodResolver(SignUpInfo),
   });
   const setSignUpEmailUser = useSetRecoilState(SignUpEmailUserAtom);
 
-  const onSubmit = (data: SignUpFormData1Type) => {
+  const onSubmit = (data: SignUpInfoType) => {
     setSignUpEmailUser(prev => ({
       ...prev,
       name: data.name,
       birth: Number(data.birth),
       gender: data.gender === 1 || data.gender === 3 ? 1 : 2,
     }));
-
-    step(1);
   };
 
   return (

--- a/src/components/templates/SignUpInfo.template.tsx
+++ b/src/components/templates/SignUpInfo.template.tsx
@@ -1,28 +1,23 @@
 import { FormProvider, useForm } from 'react-hook-form';
-import { useSetRecoilState } from 'recoil';
 import { zodResolver } from '@hookform/resolvers/zod';
 
 import Container from '@/components/atoms/Container';
 import Typography from '@/components/atoms/Typography';
 import Button from '@/components/atoms/Button';
-import { SignUpEmailUserAtom } from '@/stores/sign.store';
 import FormItem from '@/components/molecules/FormItem';
 import { SignUpInfo, SignUpInfoType } from '@/types/auth.type';
+import { useUpdateUserInfo } from '@/hooks/useSign';
 
 export default function SignUpInfoTemplate() {
   const Form = FormProvider;
   const form = useForm<SignUpInfoType>({
     resolver: zodResolver(SignUpInfo),
   });
-  const setSignUpEmailUser = useSetRecoilState(SignUpEmailUserAtom);
+  const { updateUserInfo, isPending } = useUpdateUserInfo();
 
   const onSubmit = (data: SignUpInfoType) => {
-    setSignUpEmailUser(prev => ({
-      ...prev,
-      name: data.name,
-      birth: Number(data.birth),
-      gender: data.gender === 1 || data.gender === 3 ? 1 : 2,
-    }));
+    const { gender, ...others } = data;
+    updateUserInfo({ ...others, gender: gender === 1 || gender === 3 ? 1 : 2 });
   };
 
   return (
@@ -44,6 +39,7 @@ export default function SignUpInfoTemplate() {
                 name="birth"
                 placeholder="990101"
                 inputStyle="mt-[1rem]"
+                disabled={isPending}
               />
               <p className="pt-3">-</p>
               <FormItem.TextField
@@ -51,6 +47,7 @@ export default function SignUpInfoTemplate() {
                 name="gender"
                 inputStyle="mt-[2rem] "
                 containerStyle="w-[2.5rem]"
+                disabled={isPending}
               />
               <p className="pt-3">* * * * * *</p>
             </Container.FlexRow>
@@ -58,9 +55,10 @@ export default function SignUpInfoTemplate() {
           <Button.Fill
             type="submit"
             className=" mt-[3.25rem] w-full rounded-[10px]"
+            disabled={isPending}
           >
             <Typography.P3 className="mx-auto my-[1rem] text-[#F4E7DB]">
-              다음
+              완료
             </Typography.P3>
           </Button.Fill>
         </form>

--- a/src/hooks/useSign.ts
+++ b/src/hooks/useSign.ts
@@ -104,6 +104,7 @@ export const useVerifyEmail = ({
 }: {
   [key: string]: string;
 }) => {
+  const navigate = useNavigate();
   const setUser = useSetRecoilState(UserAtom);
   const { mutate: verifyEmail, isPending: isVerifyEmail } = useMutation({
     mutationFn: async (payload: VerifyEmailType) => {
@@ -119,6 +120,7 @@ export const useVerifyEmail = ({
       // * Recoil 상태로 유저정보 등록
       if (payload) setUser(payload);
       successToast('signin', successMessage);
+      navigate('/sign/up/info');
     },
     onError: (error: AuthError) => {
       errorToast('signin', error.message);

--- a/src/hooks/useSign.ts
+++ b/src/hooks/useSign.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import {
   AuthError,
   AuthResponse,
@@ -14,6 +14,7 @@ import {
   EmailAuthType,
   GoogleOAuthType,
   KakaoOAuthType,
+  SignUpEmailType,
   SocialType,
   UserAdditionalType,
   UserType,
@@ -21,7 +22,7 @@ import {
 } from '@/types/auth.type';
 import { fetchGet } from '@/libs/fetch';
 import { createToast, errorToast, successToast } from '@/libs/toast';
-import { ShowVerificationAtom, SignUpEmailUserAtom } from '@/stores/sign.store';
+import { ShowVerificationAtom } from '@/stores/sign.store';
 
 const preProcessingUserData = (
   data: AuthTokenResponsePassword | AuthResponse,
@@ -45,21 +46,17 @@ const preProcessingUserData = (
 };
 
 export const useSignUpEmail = () => {
-  const signUpEmailValue = useRecoilValue(SignUpEmailUserAtom);
+  // const signUpEmailValue = useRecoilValue(SignUpEmailUserAtom);
   const setShowVerification = useSetRecoilState(ShowVerificationAtom);
   const { mutate: signUpEmail, isPending: isSignUpEmail } = useMutation({
-    mutationFn: async () =>
+    mutationFn: async (payload: SignUpEmailType) =>
       supabase.auth.signUp({
-        email: signUpEmailValue.email,
-        password: signUpEmailValue.password,
+        email: payload.email,
+        password: payload.password,
         options: {
           data: {
             avatar: '',
-            email: signUpEmailValue.email,
-            name: signUpEmailValue.name,
-            birth: signUpEmailValue.birth,
-            gender: signUpEmailValue.gender,
-            nickName: signUpEmailValue.name,
+            email: payload.email,
             status: 0,
           },
         },

--- a/src/hooks/useSign.ts
+++ b/src/hooks/useSign.ts
@@ -7,6 +7,7 @@ import {
   Session,
 } from '@supabase/supabase-js';
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { supabase } from '@/libs/supabaseClient';
 import { IsNotVerifiedAtom, UserAtom } from '@/stores/auth.store';
@@ -15,6 +16,7 @@ import {
   GoogleOAuthType,
   KakaoOAuthType,
   SignUpEmailType,
+  SignUpInfoType,
   SocialType,
   UserAdditionalType,
   UserType,
@@ -206,6 +208,26 @@ export const userAdditionalInfo = (session: Session) => ({
     return user;
   },
 });
+
+export const useUpdateUserInfo = () => {
+  const navigate = useNavigate();
+  const { mutate: updateUserInfo, isPending } = useMutation({
+    mutationFn: async (payload: SignUpInfoType) => {
+      const { error } = await supabase.auth.updateUser({
+        data: { ...payload, nickname: payload.name },
+      });
+      if (error) throw new Error(error.message);
+    },
+    onMutate: () =>
+      createToast('update-user-info', '기본 정보를 수정중입니다...'),
+    onSuccess: () => {
+      successToast('update-user-info', '✅기본 정보 수정을 완료했습니다.');
+      navigate('/about');
+    },
+    onError: error => errorToast('update-user-info', error.message),
+  });
+  return { updateUserInfo, isPending };
+};
 export const useUpdateUser = () => {
   // * Social 로그인에서 Gender, Birth 데이터를 DB와 연동하기 위한 훅
   const setUser = useSetRecoilState(UserAtom);

--- a/src/hooks/useSign.ts
+++ b/src/hooks/useSign.ts
@@ -8,6 +8,7 @@ import {
 } from '@supabase/supabase-js';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { uuid } from '@supabase/supabase-js/dist/main/lib/helpers';
 
 import { supabase } from '@/libs/supabaseClient';
 import { IsNotVerifiedAtom, UserAtom } from '@/stores/auth.store';
@@ -57,6 +58,7 @@ export const useSignUpEmail = () => {
         password: payload.password,
         options: {
           data: {
+            name: uuid(),
             avatar: '',
             email: payload.email,
             status: 0,

--- a/src/stores/sign.store.ts
+++ b/src/stores/sign.store.ts
@@ -1,7 +1,6 @@
 import { atom, AtomEffect, RecoilState, selectorFamily } from 'recoil';
 
 import { SignUpProfileType } from '@/types/signUp.type';
-import { SignUpUserType } from '@/types/auth.type';
 
 const signUpProfileKey = 'signUpProfile';
 
@@ -80,16 +79,4 @@ export const SignupProfileStateSelector = selectorFamily({
 export const ShowVerificationAtom = atom({
   key: 'showVerificationAtom',
   default: false,
-});
-
-export const SignUpEmailUserAtom = atom<SignUpUserType>({
-  key: 'signUpEmailUserAtom',
-  default: {
-    name: '',
-    birth: 0,
-    gender: 0,
-    email: '',
-    password: '',
-    token: undefined,
-  },
 });

--- a/src/types/auth.type.ts
+++ b/src/types/auth.type.ts
@@ -92,14 +92,6 @@ export const SignUpEmail = z
   });
 export type SignUpEmailType = z.infer<typeof SignUpEmail>;
 
-// * SignUp 1 페이지 타입 + SignUp 2 페이지 타입
-// * SignUp 2 confirmPassword는 불필요
-// * 회원가입 시 사용되는 타입
-export const SignUpUser = SignUpInfo.merge(
-  SignUpEmail.innerType().omit({ confirmPassword: true }),
-);
-export type SignUpUserType = z.infer<typeof SignUpUser>;
-
 // * 상태로 관리할 User 의 타입
 export type UserType = UserAdditionalType & {
   avatar: string;

--- a/src/types/auth.type.ts
+++ b/src/types/auth.type.ts
@@ -27,9 +27,9 @@ const UserAdditional = z.object({
 });
 export type UserAdditionalType = z.infer<typeof UserAdditional>;
 
-// * SignUp 1 페이지 타입
+// * SignUp Info 페이지 타입
 // * birth, gender는 자체 제작 SignUp 페이지에서는 필수 필드
-export const SignUpFormData1 = z.object({
+export const SignUpInfo = z.object({
   name: z
     .string({ required_error: '필수 입력 사항입니다.' })
     .min(2, { message: '최소 2글자 이상 입력해주세요.' }),
@@ -63,9 +63,9 @@ export const SignUpFormData1 = z.object({
     })
     .transform(data => Number(data)),
 });
-export type SignUpFormData1Type = z.infer<typeof SignUpFormData1>;
+export type SignUpInfoType = z.infer<typeof SignUpInfo>;
 
-// * SignUp 2 페이지 타입
+// * SignUp Email 페이지 타입
 const PasswordValidate = z
   .string({ required_error: '비밀번호를 입력해주세요.' })
   .min(8, {
@@ -74,7 +74,7 @@ const PasswordValidate = z
   .regex(/^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$/, {
     message: '영문, 숫자, 특수기호를 포함하여 8자리 이상 입력해주세요.',
   });
-export const SignUpFormData2 = z
+export const SignUpEmail = z
   .object({
     email: z
       .string({ required_error: '필수 입력 사항입니다.' })
@@ -90,13 +90,13 @@ export const SignUpFormData2 = z
     message: '비밀번호가 일치하지 않습니다.',
     path: ['confirmPassword'],
   });
-export type SignUpFormData2Type = z.infer<typeof SignUpFormData2>;
+export type SignUpEmailType = z.infer<typeof SignUpEmail>;
 
 // * SignUp 1 페이지 타입 + SignUp 2 페이지 타입
 // * SignUp 2 confirmPassword는 불필요
 // * 회원가입 시 사용되는 타입
-export const SignUpUser = SignUpFormData1.merge(
-  SignUpFormData2.innerType().omit({ confirmPassword: true }),
+export const SignUpUser = SignUpInfo.merge(
+  SignUpEmail.innerType().omit({ confirmPassword: true }),
 );
 export type SignUpUserType = z.infer<typeof SignUpUser>;
 


### PR DESCRIPTION
## 📝 개요(이미지 첨부 선택)
*<!-- 이슈에 대해 어떻게, 무엇을, 왜 수정했는지 작성해주세요. -->*

OAuth 회원가입의 기존 방식은 각 외부 API로 해당 OAuth 정보를 가져와 저장하는 방식이었지만 사용자가 직접 정의한 성별을 저장하여 우리가 필요한 남성, 여성에 대한 구분이 불가능

따라서 OAuth로 회원가입 시 해당 유저의 이름, 성별, 생일을 자체 제작한 페이지에서 입력받아 등록

자체 제작한 페이지가 현재는 /sign/up 페이지 내부에서 Carousel로 동작하여 이름, 성별, 생일 뿐 아니라 이메일 입력 및 패스워드 입력 페이지가 같이 보이게 되어있어 해당 페이지를 분리

1. /sign/up -> 이메일 입력, 패스워드 입력 및 메일 인증
2. /sign/up/info -> 이름, 성별, 생일 입력

### 로직 구현
회원가입 클릭 ->
/sign/up 페이지로 이동 -> 
페이지에서 이메일, 패스워드 입력 후 인증하기 -> 
메일로 인증번호를 받아 입력 ->
정상적으로 인증이 완료 시 /sign/up/info 페이지로 이동

### 추가할 로직
+ OAuth 부분을 수정하여 회원가입 시 /sign/up/info 페이지로 이동
+ about과 같은 페이지 혹은 레이아웃 단에서 로그인 된 유저의 birth, gender, nickname 등의 데이터가 없을 경우 /sign/up/info 페이지로 이동

### 작업 내용
1. Carousel 제거
2. 회원가입 로직 분리 
  Email, Password 관련 로직 + 이름, 생년월일, 성별 관련 로직을 분리하여 각 페이지에 적용
3. FormItem.Password에 Visible 아이콘 탭 포커스가 가지 않도록 변경
  ```tsx
      <IconButton.Ghost
        tabIndex={-1} // 추가하여 포커스 이동 방지
        className="absolute bottom-[44px] right-[13px] top-[53px]"
      ...
  ```
## ✅ PR 유형
어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [] CSS 등 사용자 UI 디자인 변경
- [X] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.  
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [ ] 모든 팀원이 PR에 대한 리뷰를 진행했습니다.
- [ ] 이 코드 변경 사항은 기존 기능에 영향을 주지 않나요?
- [X] 팀원이 이해할 수 있도록 충분한 주석 및 코드 일관성을 준수했나요? (변수명, 함수명, 클래스명, 가독성 등)

## 💁‍♂️ PR 추가 정보
*<!-- PR과 관련된 기타 정보(E.G 개선사항, 리뷰어가 봐주었으면 하는 점)가 있다면 여기에 적어주세요. -->*